### PR TITLE
Publish binary releases

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -1,0 +1,116 @@
+#
+#  Copyright 2021 The original authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+name: EarlyAccess
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  # Build native executable per runner
+  build:
+    name: 'Build with Graal on ${{ matrix.os }}'
+    if: github.repository == 'gunnarmorling/kcctl' && startsWith(github.event.head_commit.message, 'Releasing version') != true
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ ubuntu-latest, macOS-latest, windows-latest ]
+        gu-binary: [ gu, gu.cmd ]
+        exclude:
+          - os: ubuntu-latest
+            gu-binary: gu.cmd
+          - os: macos-latest
+            gu-binary: gu.cmd
+          - os: windows-latest
+            gu-binary: gu
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: 'Check out repository'
+        uses: actions/checkout@v2
+        
+      - name: 'Add Developer Command Prompt for Microsoft Visual C++ '
+        if: ${{ runner.os == 'Windows' }}
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: 'Set up Graal'
+        uses: DeLaGuardo/setup-graalvm@4.0
+        with:
+          graalvm: '21.1.0'
+          java: 'java11'
+
+      - name: 'Install native-image component'
+        run: |
+          ${{ matrix.gu-binary }} install native-image
+
+      - name: 'Cache Maven packages'
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: 'Build Native Image'
+        run: mvn -B --file pom.xml -Pnative package
+
+      - name: 'Create distribution'
+        run: mvn -B --file pom.xml -Pdist package -DskipTests
+
+      - name: 'Upload build artifact'
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifacts
+          path: target/*.zip
+
+  # Collect all executables and release
+  release:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 'Check out repository'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: 'Download all build artifacts'
+        uses: actions/download-artifact@v2
+
+      - name: 'Set up Java'
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: 'zulu'
+
+      - name: 'Version'
+        id: version
+        run: |
+          POM_VERSION=`grep -oE -m 1 "<version>(.*)</version>" pom.xml | awk 'match($0, />.*?</) { print substr($0, RSTART+1, RLENGTH-2); }'`
+          KCCTL_VERSION=`echo $POM_VERSION | awk 'match($0, /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)/) { print substr($0, RSTART, RLENGTH); }'`
+          echo "POM_VERSION = $POM_VERSION"
+          echo "KCCTL_VERSION = $KCCTL_VERSION"
+          echo "::set-output name=POM_VERSION::$POM_VERSION"
+          echo "::set-output name=KCCTL_VERSION::$KCCTL_VERSION"
+
+      - name: 'Release with JReleaser'
+        uses: jreleaser/release-action@v1
+        with:
+          version: early-access
+        env:
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JRELEASER_PROJECT_VERSION: ${{ steps.version.outputs.POM_VERSION }}
+          KCCTL_VERSION: ${{ steps.version.outputs.KCCTL_VERSION }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,9 +14,6 @@
 #  limitations under the License.
 #
 
-# This workflow will build a Java project with Maven
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
-
 name: Java CI with Maven
 
 on:
@@ -27,20 +24,81 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    name: 'Build with Graal on ${{ matrix.os }}'
+    strategy:
+      fail-fast: true
+      matrix:
+        #os: [ ubuntu-latest, macOS-latest, windows-latest ]
+        #gu-binary: [ gu, gu.cmd ]
+        #exclude:
+        #  - os: ubuntu-latest
+        #    gu-binary: gu.cmd
+        #  - os: macos-latest
+        #    gu-binary: gu.cmd
+        #  - os: windows-latest
+        #    gu-binary: gu
+        os: [ ubuntu-latest, macOS-latest ]
+        gu-binary: [ gu ]
+    runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11
-    - name: Cache Maven packages
-      uses: actions/cache@v1
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
-    - name: Build with Maven
-      run: mvn -B install --file pom.xml
+      - name: 'Check out repository'
+        uses: actions/checkout@v2
+
+      - name: 'Set up Graal'
+        uses: DeLaGuardo/setup-graalvm@4.0
+        with:
+          graalvm: '21.1.0'
+          java: 'java11'
+
+      - name: 'Install native-image component'
+        run: |
+          ${{ matrix.gu-binary }} install native-image
+
+      - name: 'Cache Maven packages'
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: 'Build Native Image'
+        run: mvn -B --file pom.xml -Pnative package
+
+      - name: 'Create Distribution'
+        run: mvn -B --file pom.xml -Pdist package -DskipTests
+
+      - name: 'Upload Build Artifact'
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifact
+          path: target/*.zip
+
+  release:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Check out repository'
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: 'Download all build artifacts'
+        uses: actions/download-artifact@v2
+
+      - name: 'Display structure of downloaded files'
+        run: ls -R
+
+      - name: 'Set up Java'
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: 'zulu'
+
+      - name: 'Release with JReleaser'
+        uses: jreleaser/release-action@v1
+        with:
+          arguments: -V
+        env:
+          JRELEASER_GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+          JRELEASER_PROJECT_VERSION: 1.0.0-SNAPSHOT

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,46 +14,24 @@
 #  limitations under the License.
 #
 
-name: Java CI with Maven
+name: Build
 
 on:
   push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
   build:
-    name: 'Build with Graal on ${{ matrix.os }}'
-    strategy:
-      fail-fast: true
-      matrix:
-        #os: [ ubuntu-latest, macOS-latest, windows-latest ]
-        #gu-binary: [ gu, gu.cmd ]
-        #exclude:
-        #  - os: ubuntu-latest
-        #    gu-binary: gu.cmd
-        #  - os: macos-latest
-        #    gu-binary: gu.cmd
-        #  - os: windows-latest
-        #    gu-binary: gu
-        os: [ ubuntu-latest, macOS-latest ]
-        gu-binary: [ gu ]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: 'Check out repository'
         uses: actions/checkout@v2
 
-      - name: 'Set up Graal'
-        uses: DeLaGuardo/setup-graalvm@4.0
+      - name: 'Set up Java'
+        uses: actions/setup-java@v2
         with:
-          graalvm: '21.1.0'
-          java: 'java11'
-
-      - name: 'Install native-image component'
-        run: |
-          ${{ matrix.gu-binary }} install native-image
+          java-version: 11
+          distribution: 'zulu'
 
       - name: 'Cache Maven packages'
         uses: actions/cache@v1
@@ -62,43 +40,5 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
-      - name: 'Build Native Image'
-        run: mvn -B --file pom.xml -Pnative package
-
-      - name: 'Create Distribution'
-        run: mvn -B --file pom.xml -Pdist package -DskipTests
-
-      - name: 'Upload Build Artifact'
-        uses: actions/upload-artifact@v2
-        with:
-          name: artifact
-          path: target/*.zip
-
-  release:
-    needs: [ build ]
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'Check out repository'
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: 'Download all build artifacts'
-        uses: actions/download-artifact@v2
-
-      - name: 'Display structure of downloaded files'
-        run: ls -R
-
-      - name: 'Set up Java'
-        uses: actions/setup-java@v2
-        with:
-          java-version: 11
-          distribution: 'zulu'
-
-      - name: 'Release with JReleaser'
-        uses: jreleaser/release-action@v1
-        with:
-          arguments: -V
-        env:
-          JRELEASER_GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
-          JRELEASER_PROJECT_VERSION: 1.0.0-SNAPSHOT
+      - name: 'Build'
+        run: mvn -B --file pom.xml verify

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ nb-configuration.xml
 
 # Local environment
 .env
+
+#JReleaser
+out/

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -1,0 +1,42 @@
+#
+#  Copyright 2021 The original authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+project:
+  name: kcctl
+  description: kcctl -- A CLI for Apache Kafka Connect
+  longDescription: kcctl -- A CLI for Apache Kafka Connect
+  website: https://github.com/gunnarmorling/kcctl
+  authors:
+    - Gunnar Morling
+  license: Apache-2.0
+  snapshot:
+    label: '{{ Env.KCCTL_VERSION }}-early-access'
+  extraProperties:
+    inceptionYear: 2021
+
+distributions:
+  kcctl:
+    type: NATIVE_IMAGE
+    artifacts:
+      - path: 'artifacts/{{distributionName}}-{{projectVersion}}-linux-x86_64.zip'
+        transform: 'artifacts/{{distributionName}}-{{projectEffectiveVersion}}-linux-x86_64.zip'
+        platform: linux-x86_64
+      - path: 'artifacts/{{distributionName}}-{{projectVersion}}-windows-x86_64.zip'
+        transform: 'artifacts/{{distributionName}}-{{projectEffectiveVersion}}-windows-x86_64.zip'
+        platform: windows-x86_64
+      - path: 'artifacts/{{distributionName}}-{{projectVersion}}-osx-x86_64.zip'
+        transform: 'artifacts/{{distributionName}}-{{projectEffectiveVersion}}-osx-x86_64.zip'
+        platform: osx-x86_64

--- a/pom.xml
+++ b/pom.xml
@@ -187,21 +187,43 @@
             </goals>
             <phase>process-sources</phase>
           </execution>
-      </executions>
-    </plugin>
-    <plugin>
-      <groupId>net.revelc.code</groupId>
-      <artifactId>impsort-maven-plugin</artifactId>
-      <executions>
-        <execution>
-          <id>sort-imports</id>
-          <goals>
-            <goal>sort</goal>
-          </goals>
-          <phase>process-sources</phase>
-        </execution>
-      </executions>
-    </plugin>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>net.revelc.code</groupId>
+        <artifactId>impsort-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>sort-imports</id>
+            <goals>
+              <goal>sort</goal>
+            </goals>
+            <phase>process-sources</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <attach>false</attach>
+          <appendAssemblyId>false</appendAssemblyId>
+          <finalName>kcctl-${project.version}-${os.detected.classifier}</finalName>
+          <outputDirectory>${app.distribution.directory}</outputDirectory>
+          <workDirectory>${project.build.directory}/assembly/work</workDirectory>
+          <skipAssembly>true</skipAssembly>
+        </configuration>
+        <executions>
+          <execution>
+            <id>make-distribution</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
@@ -252,26 +274,34 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-assembly-plugin</artifactId>
-            <version>3.2.0</version>
-            <configuration>
-              <attach>false</attach>
-              <appendAssemblyId>false</appendAssemblyId>
-              <finalName>kcctl-${project.version}-${os.detected.classifier}</finalName>
+            <configuration combine.self="append">
+              <skipAssembly>false</skipAssembly>
               <descriptors>
                 <descriptor>src/main/assembly/assembly.xml</descriptor>
               </descriptors>
-              <outputDirectory>${app.distribution.directory}</outputDirectory>
-              <workDirectory>${project.build.directory}/assembly/work</workDirectory>
             </configuration>
-            <executions>
-              <execution>
-                <id>make-distribution</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>single</goal>
-                </goals>
-              </execution>
-            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>dist-windows</id>
+      <activation>
+        <os>
+          <family>windows</family>
+        </os>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <configuration combine.self="append">
+              <skipAssembly>false</skipAssembly>
+              <descriptors>
+                <descriptor>src/main/assembly/assembly-windows.xml</descriptor>
+              </descriptors>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,14 @@
   </dependencies>
 
   <build>
+    <!-- detect OS classifier, needed for distribution Zip file -->
+    <extensions>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.7.0</version>
+      </extension>
+    </extensions>
     <pluginManagement>
       <plugins>
         <plugin>
@@ -231,6 +239,42 @@
       <properties>
         <quarkus.package.type>native</quarkus.package.type>
       </properties>
+    </profile>
+    <profile>
+      <id>dist</id>
+      <activation>
+        <property>
+          <name>dist</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <version>3.2.0</version>
+            <configuration>
+              <attach>false</attach>
+              <appendAssemblyId>false</appendAssemblyId>
+              <finalName>kcctl-${project.version}-${os.detected.classifier}</finalName>
+              <descriptors>
+                <descriptor>src/main/assembly/assembly.xml</descriptor>
+              </descriptors>
+              <outputDirectory>${app.distribution.directory}</outputDirectory>
+              <workDirectory>${project.build.directory}/assembly/work</workDirectory>
+            </configuration>
+            <executions>
+              <execution>
+                <id>make-distribution</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>single</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>

--- a/src/main/assembly/assembly-windows.xml
+++ b/src/main/assembly/assembly-windows.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<!--
+
+     Copyright 2021 The original authors
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<assembly
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id>dist</id>
+    <formats>
+        <format>zip</format>
+        <format>dir</format>
+    </formats>
+    <files>
+        <file>
+            <source>LICENSE.txt</source>
+            <outputDirectory>./</outputDirectory>
+        </file>
+        <file>
+            <source>kcctl_completion</source>
+            <outputDirectory>./</outputDirectory>
+        </file>
+        <file>
+            <source>${project.build.directory}/${project.artifactId}-${project.version}-runner.exe</source>
+            <outputDirectory>./bin</outputDirectory>
+            <destName>kcctl.exe</destName>
+        </file>
+    </files>
+</assembly>

--- a/src/main/assembly/assembly.xml
+++ b/src/main/assembly/assembly.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<!--
+
+     Copyright 2021 The original authors
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<assembly
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id>dist</id>
+    <formats>
+        <format>zip</format>
+        <format>dir</format>
+    </formats>
+    <files>
+        <file>
+            <source>LICENSE.txt</source>
+            <outputDirectory>./</outputDirectory>
+        </file>
+        <file>
+            <source>kcctl_completion</source>
+            <outputDirectory>./</outputDirectory>
+        </file>
+        <file>
+            <source>${project.build.directory}/${project.artifactId}-${project.version}-runner</source>
+            <outputDirectory>./bin</outputDirectory>
+            <destName>kcctl</destName>
+        </file>
+    </files>
+</assembly>


### PR DESCRIPTION
Fixes https://github.com/gunnarmorling/kcctl/issues/10

- Add Maven configuration for creating Native Image distributions -> https://jreleaser.org/guide/latest/distributions/native-image.html
- Build main branch on every push.
- Publish rolling releases only when pushing to `main`.